### PR TITLE
refactor(cdc): enforce global batch size, improve processing order, and fix per-table seq tracking

### DIFF
--- a/Excalibur.DataAccess.SqlServer.Cdc/CdcProcessingState.cs
+++ b/Excalibur.DataAccess.SqlServer.Cdc/CdcProcessingState.cs
@@ -12,25 +12,25 @@ public class CdcProcessingState
 	/// <remarks>
 	///     The LSN is a unique identifier for a change operation in the database. This is used to track the progress of CDC processing.
 	/// </remarks>
-	public byte[] LastProcessedLsn { get; set; } = new byte[10];
+	public byte[] LastProcessedLsn { get; init; } = new byte[10];
 
 	/// <summary>
 	///     Gets or sets the last processed sequence value in the CDC process.
 	/// </summary>
 	/// <remarks> This value may be used to track sequence changes within a batch or transaction, if applicable. </remarks>
-	public byte[]? LastProcessedSequenceValue { get; set; } = new byte[10];
+	public byte[]? LastProcessedSequenceValue { get; init; }
 
 	/// <summary>
 	///     Gets or sets the timestamp of the last commit operation that was processed.
 	/// </summary>
 	/// <remarks> This value indicates the latest commit time for the data captured by the CDC process. </remarks>
-	public DateTime LastCommitTime { get; set; }
+	public DateTime LastCommitTime { get; init; }
 
 	/// <summary>
 	///     Gets or sets the timestamp when the CDC processing state was updated.
 	/// </summary>
 	/// <remarks> This value reflects the time at which the CDC processing state was last persisted or recorded. </remarks>
-	public DateTimeOffset ProcessedAt { get; set; }
+	public DateTimeOffset ProcessedAt { get; init; }
 
 	/// <summary>
 	///     Gets or sets the identifier for the database connection used in the CDC process.
@@ -39,11 +39,17 @@ public class CdcProcessingState
 	///     This value uniquely identifies the database connection, which can be useful for scenarios where multiple connections are used in
 	///     the CDC process.
 	/// </remarks>
-	private string DatabaseConnectionIdentifier { get; set; }
+	public string DatabaseConnectionIdentifier { get; init; }
 
 	/// <summary>
 	///     Gets or sets the name of the database being processed.
 	/// </summary>
 	/// <remarks> This property identifies the database for which CDC is being tracked. </remarks>
-	private string DatabaseName { get; set; }
+	public string DatabaseName { get; init; }
+
+	/// <summary>
+	///     Gets or sets the name of the table being processed.
+	/// </summary>
+	/// <remarks> This property identifies the table for which CDC is being tracked. </remarks>
+	public string TableName { get; init; }
 }

--- a/Excalibur.DataAccess.SqlServer.Cdc/ICdcRepository.cs
+++ b/Excalibur.DataAccess.SqlServer.Cdc/ICdcRepository.cs
@@ -78,6 +78,10 @@ public interface ICdcRepository
 	/// <param name="captureInstances"> A collection of capture instance names to query for changes. </param>
 	/// <param name="cancellationToken"> A token to observe while waiting for the task to complete. </param>
 	/// <returns> An asynchronous stream of <see cref="CdcRow" /> instances representing the captured changes. </returns>
-	IAsyncEnumerable<CdcRow> FetchChangesAsync(byte[] fromPosition, byte[] toPosition, byte[]? lastSequenceValue, int batchSize,
-		IEnumerable<string> captureInstances, CancellationToken cancellationToken);
+	Task<IEnumerable<CdcRow>> FetchChangesAsync(
+		string captureInstance,
+		byte[] fromPosition,
+		byte[] toPosition,
+		byte[]? lastSequenceValue,
+		CancellationToken cancellationToken);
 }

--- a/Excalibur.DataAccess.SqlServer.Cdc/ICdcStateStore.cs
+++ b/Excalibur.DataAccess.SqlServer.Cdc/ICdcStateStore.cs
@@ -12,10 +12,10 @@ public interface ICdcStateStore
 	/// <param name="databaseName"> The name of the database to retrieve the processing state for. </param>
 	/// <param name="cancellationToken"> A token to observe while waiting for the task to complete. </param>
 	/// <returns>
-	///     A task that represents the asynchronous operation, containing the last processed <see cref="CdcProcessingState" /> if found, or
-	///     <c> null </c> if no state exists.
+	///     A task that represents the asynchronous operation, containing a collection of the last processed
+	///     <see cref="CdcProcessingState" /> for each capture instance.
 	/// </returns>
-	Task<CdcProcessingState?> GetLastProcessedPositionAsync(
+	Task<IEnumerable<CdcProcessingState>> GetLastProcessedPositionAsync(
 		string databaseConnectionIdentifier,
 		string databaseName,
 		CancellationToken cancellationToken);
@@ -25,6 +25,7 @@ public interface ICdcStateStore
 	/// </summary>
 	/// <param name="databaseConnectionIdentifier"> The unique identifier for the database connection. </param>
 	/// <param name="databaseName"> The name of the database to update the processing state for. </param>
+	/// <param name="tableName"> The name of the table to update the processing state for. </param>
 	/// <param name="position"> The LSN position to set as the last processed position. </param>
 	/// <param name="sequenceValue"> The sequence value associated with the last processed position, if any. </param>
 	/// <param name="commitTime"> The commit time of the last processed LSN. </param>
@@ -33,6 +34,7 @@ public interface ICdcStateStore
 	Task UpdateLastProcessedPositionAsync(
 		string databaseConnectionIdentifier,
 		string databaseName,
+		string tableName,
 		byte[] position,
 		byte[]? sequenceValue,
 		DateTime commitTime,


### PR DESCRIPTION
- Ensures `batchSize` applies globally across all capture instances, preventing queue overload.
- Fixes processing order across tables by sorting LSNs and sequence values before enqueuing.
- Tracks `lastSequenceValue` per table instead of globally, preventing incorrect filtering.
- Optimizes LSN range selection using batch time intervals for better performance.
- Improves logging for better traceability in Producer and Consumer loops.
- Reverts `FetchChangesAsync` to `Task<IEnumerable<CdcRow>>` for efficiency, avoiding unnecessary async streaming overhead.