### PR TITLE
Support tables with dots in their name. For example, a table with a n…

### DIFF
--- a/Excalibur.DataAccess.SqlServer.Cdc/CdcRepository.cs
+++ b/Excalibur.DataAccess.SqlServer.Cdc/CdcRepository.cs
@@ -76,7 +76,7 @@ public class CdcRepository : ICdcRepository
 
 		var CommandText = $"""
 		                   SELECT Top 1 __$start_lsn AS Next_LSN
-		                   FROM cdc.{captureInstance}_CT
+		                   FROM cdc.[{captureInstance}_CT]
 		                   WHERE __$start_lsn > @LastProcessedLsn
 		                   ORDER BY __$start_lsn;
 		                   """;
@@ -277,7 +277,7 @@ public class CdcRepository : ICdcRepository
 		                        __$seqval AS SequenceValue,
 		                        __$operation AS OperationCode,
 		                      *
-		                   FROM cdc.fn_cdc_get_all_changes_{captureInstance}(@lsn, @lsn, N'all update old'{extraParameters})
+		                   FROM cdc.[fn_cdc_get_all_changes_{captureInstance}](@lsn, @lsn, N'all update old'{extraParameters})
 		                   WHERE
 		                      __$start_lsn = @lsn
 		                      AND


### PR DESCRIPTION
…ame such as dbo.[Work.Work] where the schema is dbo and [Work.Work] is the name of the table. Without the encapsulating [ and ], we receive errors specifying that the cdc objects don't exist. This patch fixes the issue.